### PR TITLE
crear tablas en dynamoDB usando SST

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+## Configuraciones iniciales
+
+Instalar Leapp
+    https://www.leapp.cloud/
+
+Utilizar para desarrollo el sandbox Dev: DevTestTemporalPerms
+
+## Pasos para ejecutar el proyecto
+
+Instalar dependencias
+
+    $ yarn
+
+## Comandos
+
+Inicia el entorno de desarrollo Live Lambda Dev.
+
+    yarn sst dev --stage=[your_name]
+
+Despliega todas tus pilas en AWS. Opcionalmente, despliega una pila específica.
+
+    yarn run remove --stage=[your_name]

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,0 +1,16 @@
+import { SSTConfig } from "sst";
+import { DocumentStatesTable, DocumentKeysTable } from "./stacks/Tables"
+
+export default {
+  config(_input) {
+    return {
+      name: "truora-DynamoDB",
+      region: "us-east-1",
+    };
+  },
+  stacks(app) {
+    app
+    .stack(DocumentStatesTable)
+    .stack(DocumentKeysTable);
+  }
+} satisfies SSTConfig;

--- a/stacks/Api.ts
+++ b/stacks/Api.ts
@@ -1,0 +1,14 @@
+import { StackContext, Api } from "sst/constructs";
+
+export function API({ stack }: StackContext) {
+
+  const api = new Api(stack, "api", {
+    routes: {
+      "GET /": "packages/functions/src/lambda.handler",
+    },
+  });
+
+  stack.addOutputs({
+    ApiEndpoint: api.url,
+  });
+}

--- a/stacks/Tables.ts
+++ b/stacks/Tables.ts
@@ -1,0 +1,33 @@
+import { StackContext, Table } from "sst/constructs"
+
+export function DocumentStatesTable({ stack }: StackContext) {
+	const documentStatesTable = new Table(stack, "DocumentStatesTable", {
+		fields: {
+            userId: "string",
+			documentType: "string",
+			state: "string",
+		},
+		primaryIndex: {
+			partitionKey: "userId", sortKey: "state"
+		},
+	})
+
+	return {
+		documentStatesTable,
+	}
+}
+
+export function DocumentKeysTable({ stack }: StackContext) {
+	const documentKeysTable = new Table(stack, "DocumentKeysTable", {
+		fields: {
+			documentId: "string",
+		},
+		primaryIndex: {
+			partitionKey: "documentId",
+		},
+	})
+
+	return {
+		documentKeysTable,
+	}
+}


### PR DESCRIPTION
Ticket JIRA:  [TEC-678](https://sherpawmc.atlassian.net/jira/software/c/projects/TEC/boards/1?selectedIssue=TEC-678)

**De que trata el PR:**

Servira para definir las tablas en DynamoDB para guardar data  (las llaves, token, etc)

[TEC-678]: https://sherpawmc.atlassian.net/browse/TEC-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced the Leapp configuration and installation instructions in the README.md file.
- New Feature: Added two new AWS DynamoDB tables, `DocumentStatesTable` and `DocumentKeysTable`, for managing document states and keys respectively.
- New Feature: Implemented a new API endpoint (GET request to "/") with a specific lambda function as its handler.
- Refactor: Updated the Serverless Stack Toolkit (SST) configuration to include the newly created tables and API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->